### PR TITLE
MarkDown file Dottydoc bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,6 @@ jdk:
   - openjdk8
 
 script:
+  - sbt doc
   - sbt run
   - sbt 'set scalaVersion := dottyLatestNightlyBuild.get' run

--- a/doc/UserGuide.md
+++ b/doc/UserGuide.md
@@ -1,0 +1,3 @@
+# UserGuide
+
+This is the user guide.


### PR DESCRIPTION
Trying to reproduce the bug from ScalaCheck here as a minimal example, but adding a Markdown file, dottydoc works fine with no problem with this dotty-example-project.

This is something that we're experiencing with ScalaCheck, see:

https://github.com/typelevel/scalacheck/pull/565
